### PR TITLE
[Fix] Only commit and push if action publishes package(s)

### DIFF
--- a/publish-releases/entrypoint.sh
+++ b/publish-releases/entrypoint.sh
@@ -142,11 +142,11 @@ function publish(){
       publish_command --access=public
       git add package.json
       echo -e "${GREEN}Successfully published version ${BLUE}${version}${GREEN} of ${BLUE}${package}${GREEN}!${NC}"
+      echo $(jq --arg PKG "$package_name" '.packages[.packages | length] |= . + $PKG' $HOME/published.json) > ~/published.json
     else
      echo -e "${RED}Version ${YELLOW}$version${RED} of ${YELLOW}$package${RED} already exists.${NC}"
     fi
 
-    echo $(jq --arg PKG "$package_name" '.packages[.packages | length] |= . + $PKG' $HOME/published.json) > ~/published.json
     cd $GITHUB_WORKSPACE
   done
 }


### PR DESCRIPTION
`publish-releases` will add, commit, and push if there are confirmed publishes which is populated in a file called `published.json` (created and disposed within the action). So this file should be populated unless we publish and so the one line of code needed to be rearranged to the appropriate spot.