### PR TITLE
Remove .npmrc file from repository for preview action

### DIFF
--- a/publish-previews/entrypoint.sh
+++ b/publish-previews/entrypoint.sh
@@ -251,7 +251,6 @@ function remove_npmrc(){
     echo -e "${YELLOW}.npmrc detected: Removing npmrc file from repository...${NC}"
     rm .npmrc
   fi
-  ls
   check_prerequisites
 }
 

--- a/publish-previews/entrypoint.sh
+++ b/publish-previews/entrypoint.sh
@@ -251,6 +251,7 @@ function remove_npmrc(){
     echo -e "${YELLOW}.npmrc detected: Removing npmrc file from repository...${NC}"
     rm .npmrc
   fi
+  ls
   check_prerequisites
 }
 

--- a/publish-previews/entrypoint.sh
+++ b/publish-previews/entrypoint.sh
@@ -246,4 +246,12 @@ EOT
   fi
 }
 
-check_prerequisites
+function remove_npmrc(){
+  if [ -f ".npmrc" ]; then
+    echo -e "${YELLOW}.npmrc detected: Removing npmrc file from repository...${NC}"
+    rm .npmrc
+  fi
+  check_prerequisites
+}
+
+remove_npmrc


### PR DESCRIPTION
### Motivation
`@resideo/zeus` now requires an `.npmrc` file on its repository for Netlify to be able to fetch private dependencies but it's getting in the way of what the action needs to do.

### Approach
The action, at the beginning of its execution, will look for an `.npmrc` file and if it exists we remove it.