### PR TITLE
Add conditionals to skip private packages

### DIFF
--- a/publish-previews/entrypoint.sh
+++ b/publish-previews/entrypoint.sh
@@ -45,11 +45,14 @@ function publish(){
 
     json_within=($(find . -name 'package.json' -not -path './node_modules/*'));
     json_count=${#json_within[@]};
+    is_private=$(echo $(jq '.private' package.json))
 
     pkgname="`node -e \"console.log(require('./package.json').name)\"`"
 
     if [ "$json_count" != "1" ]; then
       echo -e "${RED}Skipping publishing process for: ${YELLOW}$dir${RED} because there is a sub-package.${NC}"
+    elif [ "$is_private" = "true" ]; then
+      echo -e "${RED}Skipping publishing process for: ${YELLOW}$dir${RED} because package is marked as private and therefore not intended to be published.${NC}"
     else
       echo -e "${GREEN}Running publishing process for: ${YELLOW}$dir${NC}"
       npm_version_SHA

--- a/publish-releases/entrypoint.sh
+++ b/publish-releases/entrypoint.sh
@@ -132,17 +132,17 @@ function publish(){
   for package in ${publish_directories[@]}; do
     cd $GITHUB_WORKSPACE/$package
 
-    package_name="`node -e \"console.log(require('./package.json').name)\"`"
-    echo -e "${GREEN}Running publishing process for: ${YELLOW}$package_name${NC}"
-
-    version_bumper
-    version="`node -e \"console.log(require('./package.json').version)\"`"
-
     is_private=$(echo $(jq '.private' package.json))
 
     if [ "$is_private" = "true" ]; then
       echo -e "${RED}Skipping publishing process for: ${YELLOW}$dir${RED} because package is marked as private and therefore not intended to be published.${NC}"
     else
+      package_name="`node -e \"console.log(require('./package.json').name)\"`"
+      echo -e "${GREEN}Running publishing process for: ${YELLOW}$package_name${NC}"
+
+      version_bumper
+      version="`node -e \"console.log(require('./package.json').version)\"`"
+
       if [ -z "$(npm view ${package_name}@${version})" ]; then
         publish_command --access=public
         git add package.json

--- a/publish-releases/entrypoint.sh
+++ b/publish-releases/entrypoint.sh
@@ -138,13 +138,19 @@ function publish(){
     version_bumper
     version="`node -e \"console.log(require('./package.json').version)\"`"
 
-    if [ -z "$(npm view ${package_name}@${version})" ]; then
-      publish_command --access=public
-      git add package.json
-      echo -e "${GREEN}Successfully published version ${BLUE}${version}${GREEN} of ${BLUE}${package}${GREEN}!${NC}"
-      echo $(jq --arg PKG "$package_name" '.packages[.packages | length] |= . + $PKG' $HOME/published.json) > ~/published.json
+    is_private=$(echo $(jq '.private' package.json))
+
+    if [ "$is_private" = "true" ]; then
+      echo -e "${RED}Skipping publishing process for: ${YELLOW}$dir${RED} because package is marked as private and therefore not intended to be published.${NC}"
     else
-     echo -e "${RED}Version ${YELLOW}$version${RED} of ${YELLOW}$package${RED} already exists.${NC}"
+      if [ -z "$(npm view ${package_name}@${version})" ]; then
+        publish_command --access=public
+        git add package.json
+        echo -e "${GREEN}Successfully published version ${BLUE}${version}${GREEN} of ${BLUE}${package}${GREEN}!${NC}"
+        echo $(jq --arg PKG "$package_name" '.packages[.packages | length] |= . + $PKG' $HOME/published.json) > ~/published.json
+      else
+      echo -e "${RED}Version ${YELLOW}$version${RED} of ${YELLOW}$package${RED} already exists.${NC}"
+      fi
     fi
 
     cd $GITHUB_WORKSPACE


### PR DESCRIPTION
## Motivation
There are some packages in a monorepo that should not be published. NPM CLI will prevent packages configured as `"private": true` from being published by returning an error. We want our actions to just skip the publishing process and not halt the entire workflow.

## Approach
When the two actions are cycling through the directories of packages to try and publish, now it will detect to see if `private` is set to true. And if so, it will just skip that package and continue on with the next package for the publishing process.