### PR TITLE
Update generated pull request comment contents

### DIFF
--- a/publish-previews/entrypoint.sh
+++ b/publish-previews/entrypoint.sh
@@ -85,10 +85,7 @@ cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
 const pjson = require('./published.json');
 
-const branch = process.env.GITHUB_HEAD_REF;
-const masked = branch.replace(/\//g, '_');
-
-const first_line = `A preview package of this pull request has been published with the tag \`${masked}\`.`;
+const first_line = `A preview package of this pull request has been published.`;
 const second_line = `You can try it out by running the following command:`;
 const install_tag = `$ npm install ${pjson.packages[0].name}@${pjson.packages[0].version}`;
 const fourth_line = `or by updating your package.json to:`

--- a/publish-previews/entrypoint.sh
+++ b/publish-previews/entrypoint.sh
@@ -47,7 +47,7 @@ function publish(){
     json_count=${#json_within[@]};
     is_private=$(echo $(jq '.private' package.json))
 
-    pkgname="`node -e \"console.log(require('./package.json').version)\"`"
+    pkgname="`node -e \"console.log(require('./package.json').name)\"`"
 
     if [ "$json_count" != "1" ]; then
       echo -e "${RED}Skipping publishing process for: ${YELLOW}$dir${RED} because there is a sub-package.${NC}"

--- a/publish-previews/entrypoint.sh
+++ b/publish-previews/entrypoint.sh
@@ -85,7 +85,7 @@ cat << "EOT" > dangerfile.js
 const { markdown } = require('danger');
 const pjson = require('./published.json');
 
-const first_line = `A preview package of this pull request has been published.`;
+const first_line = `A preview package from this pull request has been published.`;
 const second_line = `You can try it out by running the following command:`;
 const install_tag = `$ npm install ${pjson.packages[0].name}@${pjson.packages[0].version}`;
 const fourth_line = `or by updating your package.json to:`


### PR DESCRIPTION
### Motivation
As per requested by Frontside members working on Resideo projects, I've updated the contents of the comments generated on pull requests through the preview action. 

### Approach
Instead of displaying instructions on how to install packages using the branch name as its tag, now it displays how to install the preview packages using SHA instead.

### Tests
You can see the successful results of the new changes in [this](https://github.com/resideo/zeus/pull/352) pull request.