### PR TITLE
Remove npmrc before publish and danger

### DIFF
--- a/publish-previews/entrypoint.sh
+++ b/publish-previews/entrypoint.sh
@@ -12,6 +12,7 @@ function run_danger(){
   yarn global add danger --dev
   export PATH="$(yarn global bin):$PATH"
   echo -e "${BLUE}Running Danger CI..${NC}"
+  remove_npmrc
   danger ci
 }
 
@@ -38,6 +39,7 @@ function publish(){
   echo "//npm.pkg.github.com/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
   echo "unsafe-perm=true" >> ~/.npmrc
   
+  remove_npmrc
   install_with_CLI
 
   for dir in ${confirmed_directories_array[@]}; do
@@ -254,7 +256,6 @@ function remove_npmrc(){
     echo -e "${YELLOW}.npmrc detected: Removing npmrc file from repository...${NC}"
     rm .npmrc
   fi
-  check_prerequisites
 }
 
-remove_npmrc
+check_prerequisites


### PR DESCRIPTION
Made an oopsy. I set the action to remove `.npmrc` file from the repository at the beginning of the action but the checkout process was bringing that file back and causing a conflict. So instead of removing at the beginning, I placed it before running danger command and before the publishing process so that it is not reintroduced.