### PR TITLE
Pin node to 12.18.4

### DIFF
--- a/publish-previews/Dockerfile
+++ b/publish-previews/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:12.18.4-alpine
 
 RUN apk add --no-cache git bash git-subtree jq python make g++
 

--- a/publish-releases/Dockerfile
+++ b/publish-releases/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine
+FROM node:12.18.4-alpine
 
 RUN apk add --no-cache git bash git-subtree tree jq
 


### PR DESCRIPTION
Across the @resideo org the trend appears to be for node `engines` to be set explicitly to 12.8.4. To enable those packages to build and execute it is required to pin the node version in the DOCKERFILE